### PR TITLE
Unsplash Singleton

### DIFF
--- a/src/service/unsplash.js
+++ b/src/service/unsplash.js
@@ -1,7 +1,8 @@
 import Unsplash from 'unsplash-js';
 
+let unsplash;
+
 function getUnsplash() {
-  let unsplash;
   const unsplashIsNotExist = unsplash == null;
   const unsplashIsNotInstance = (unsplash instanceof Unsplash) === false;
 


### PR DESCRIPTION
Суть в том, чтобы не создавать при каждом вызове Unsplash, а брать уже созданный (если такой есть). А если поместить `let unsplash;` внутрь функции, то проверка `const unsplashIsNotExist = unsplash == null;` всегда будет `true`, а значит смысла в следующем условии нет.